### PR TITLE
Splitted settings into two flash partitions, with separated magics

### DIFF
--- a/wordclock/animations.c
+++ b/wordclock/animations.c
@@ -102,7 +102,7 @@ const uint8_t _smiley2[] = {
 
 
 void ShowSplash(){
-	if (g_settings.hardwareType == HARDWARE_13_13) {
+	if (g_hw_settings.hardwareType == HARDWARE_13_13) {
 		DisplayWord("By RMW");
 	} else {
 		AlsFill(5,5,5);

--- a/wordclock/clock_words.c
+++ b/wordclock/clock_words.c
@@ -414,7 +414,7 @@ void CWDisplayAccurateTime(uint32_t hours, uint32_t minutes,  uint32_t seconds, 
 
 void CWInit() {
 	
-	switch (g_settings.hardwareType) {
+	switch (g_hw_settings.hardwareType) {
 		case HARDWARE_9_8:
 			_klockWords = _klockWords_9x8;
 		break;

--- a/wordclock/displaySettings.c
+++ b/wordclock/displaySettings.c
@@ -133,13 +133,13 @@ uint8_t ApplyBgBrightness(uint8_t color)
 }
 
 static void WS2812_I2S_WriteData(TPixel* pixels, uint32_t nrOfPixels){  
-    if (g_settings.pixelType == PIXEL_TYPE_RGB) {
+    if (g_hw_settings.pixelType == PIXEL_TYPE_RGB) {
         ws2812_i2s_update((ws2812_pixel_t*) pixels, PIXEL_RGB);
     } else {
         // For the RGBW leds the white LED is used to show common value,
         // The calculated RGBW value should not be stored in the frame, therefor make a copy
         for (int i = 0; i < nrOfPixels; i++) {
-            rgb2rgbw(_frameCopy[i], pixels[i], g_settings.pixelType);
+            rgb2rgbw(_frameCopy[i], pixels[i], g_hw_settings.pixelType);
         }
         ws2812_i2s_update((ws2812_pixel_t*) _frameCopy, PIXEL_RGBW);
     }
@@ -153,14 +153,14 @@ void wordClockDisplay_init(void)
     // Configure the GPIO
     gpio_enable(LEDSTRIP_GPIO_NR, GPIO_OUTPUT);
 
-    printf("###ws2812##hardwareTyp is %d\n", g_settings.hardwareType);
-    if (g_settings.hardwareType == HARDWARE_13_13 || g_settings.hardwareType == HARDWARE_13_13_V2 || g_settings.hardwareType == HARDWARE_13_13_NOT_ACCURATE) {
+    printf("###ws2812##hardwareTyp is %d\n", g_hw_settings.hardwareType);
+    if (g_hw_settings.hardwareType == HARDWARE_13_13 || g_hw_settings.hardwareType == HARDWARE_13_13_V2 || g_hw_settings.hardwareType == HARDWARE_13_13_NOT_ACCURATE) {
         _displaySize[0] = 13;
         _displaySize[1] = 13;
-    } else if (g_settings.hardwareType == HARDWARE_11_11) {
+    } else if (g_hw_settings.hardwareType == HARDWARE_11_11) {
         _displaySize[0] = 11;
         _displaySize[1] = 11;
-    } else if (g_settings.hardwareType == HARDWARE_9_8) {
+    } else if (g_hw_settings.hardwareType == HARDWARE_9_8) {
         _displaySize[0] = 9;
         _displaySize[1] = 8;
     } else {
@@ -169,7 +169,7 @@ void wordClockDisplay_init(void)
     }
 
     CWInit();
-    if (g_settings.pixelType == PIXEL_TYPE_RGB) {
+    if (g_hw_settings.pixelType == PIXEL_TYPE_RGB) {
         ws2812_i2s_init(_displaySize[0] *_displaySize[1], PIXEL_RGB);
     } else {
         ws2812_i2s_init(_displaySize[0] *_displaySize[1], PIXEL_RGBW);

--- a/wordclock/http_server.c
+++ b/wordclock/http_server.c
@@ -780,13 +780,13 @@ static void handle_hw_cfg(int s, wificfg_method method,
     	// Hardware Version
 		for (int i = 0; i < NR_OF_HARDWARE_TYPES; i++) {
 			if (wificfg_write_string(s, http_hw_cfg_content[++idx]) < 0) return;
-			if (g_settings.hardwareType == i) wificfg_write_string(s, "selected");
+			if (g_hw_settings.hardwareType == i) wificfg_write_string(s, "selected");
 		}
 
         // Pixel Types
 		for (int i = 0; i < NR_OF_PIXEL_TYPES; i++) {
 			if (wificfg_write_string(s, http_hw_cfg_content[++idx]) < 0) return;
-			if (g_settings.pixelType == i) wificfg_write_string(s, "selected");
+			if (g_hw_settings.pixelType == i) wificfg_write_string(s, "selected");
 		}
         // Perfect Imperfections
         wificfg_write_string(s, http_hw_cfg_content[++idx]);
@@ -872,9 +872,9 @@ static void handle_hw_cfg_post(int s, wificfg_method method,
             wificfg_form_url_decode(buf);
             printf("%s %s %s\n", __FUNCTION__, name, buf);
             if (strcmp(name, "hw_hardwaretype") == 0) {
-                g_settings.hardwareType = atoi(buf);
+                g_hw_settings.hardwareType = atoi(buf);
             } else if (strcmp(name, "hw_pixeltype") == 0) {
-                g_settings.pixelType = atoi(buf);
+                g_hw_settings.pixelType = atoi(buf);
             } else if (strcmp(name, "hw_imperfections") == 0) {
                 if (strstr(buf, "CheckOn") != NULL) {
                     g_settings.perfectImperfections = 1;
@@ -901,7 +901,7 @@ static void handle_hw_cfg_post(int s, wificfg_method method,
             } else if (strcmp(name, "image_Type") == 0) {
                 g_settings.otaFwType = atoi(buf);
             } else if (strcmp(name, "cl_command") == 0) {
-                printf("cl_command: %s", buf);
+                printf("cl_command: %s\n", buf);
             	if (strcmp(buf, "SetHome") == 0){
                     HbiGetLatLon(&g_settings.hierbenikHomeLat, &g_settings.hierbenikHomeLon);
                     printf("%f %f\n", g_settings.hierbenikHomeLat, g_settings.hierbenikHomeLon);

--- a/wordclock/settings.c
+++ b/wordclock/settings.c
@@ -22,34 +22,34 @@
 
 static volatile uint32_t g_storeTS = 0;
 static const TSettings g_settings_default __attribute__((aligned(4))) = {
-     FLASH_MAGIC,
-     ANIMATION_TRANSITION,
-     TEXTEFFECT_NONE, // textEffect
+    FLASH_MAGIC,
+    ANIMATION_TRANSITION,
+    TEXTEFFECT_NONE, // textEffect
 #ifdef BUILD_BY_RUTGER
-     0,   // perfectImperfections
+    0,   // perfectImperfections
 #else
-     1,   // perfectImperfections
+    1,   // perfectImperfections
 #endif
-     "",  // hierbenikUrl
-     "80",   // hierbenikPort
-     "/get_with_age.php",  // hierbenikRequest
-     0.0, // home lat
-     0.0, // home lon
+    "",  // hierbenikUrl
+    "80",   // hierbenikPort
+    "/get_with_age.php",  // hierbenikRequest
+    0.0, // home lat
+    0.0, // home lon
 #ifdef BUILD_BY_RUTGER
-     "http://rutger798.mynetgear.com",  // otaFwUrl
-     "8090",   // otaFwPort
+    "http://rutger798.mynetgear.com",  // otaFwUrl
+    "8090",   // otaFwPort
 #else
-     "http://download.wssns.nl",  // otaFwUrl
-     "80",   // otaFwPort
+    "http://download.wssns.nl",  // otaFwUrl
+    "80",   // otaFwPort
 #endif
-     OTA_FW_RELEASE, //otaFwType
-     {2, 4, 7, 10, 15, 25, 40, 60, 90, 120, 150, 170},
-     1, // reserved
-     0, // brightnessOffset
-     {255,255,255}, // colorIdx = White
-     {0,0,0},       // bgColorIdx = Black
-     52220, // timerPeriodTicks
-     FLASH_MAGIC
+    OTA_FW_RELEASE, //otaFwType
+    {2, 4, 7, 10, 15, 25, 40, 60, 90, 120, 150, 170},
+    1, // reserved
+    0, // brightnessOffset
+    {255,255,255}, // colorIdx = White
+    {0,0,0},       // bgColorIdx = Black
+    52220, // timerPeriodTicks
+    {0}, //reserved[]
 };
 
 static const THwSettings g_hw_settings_default __attribute__((aligned(4))) = {
@@ -60,7 +60,7 @@ static const THwSettings g_hw_settings_default __attribute__((aligned(4))) = {
     HARDWARE_11_11,
 #endif
     PIXEL_TYPE_RGB,
-    {0},
+    {0}, //reserved[]
 };
 
 void SettingsInit() {

--- a/wordclock/settings.h
+++ b/wordclock/settings.h
@@ -62,7 +62,7 @@ typedef struct {
     TColor color;
     TColor bgColor;
     uint32_t timerPeriodTicks;
-    uint32_t magic_end;
+    uint8_t reserved[128];
 } TSettings;
 
 // The HW settings are static for a certain hardware build.
@@ -72,7 +72,7 @@ typedef struct {
     uint32_t magic;
     EHardwareType hardwareType;
     EPixelType pixelType;
-    uint8_t reserved[256];
+    uint8_t reserved[128];
 } THwSettings;
 
 TSettings g_settings __attribute__((aligned(4)));

--- a/wordclock/settings.h
+++ b/wordclock/settings.h
@@ -15,7 +15,8 @@
 #include "displaySettings.h"
 #include "AddressableLedStrip.h"
 
-#define FLASH_MAGIC 0xBABEBAB4
+#define FLASH_MAGIC 0xBABEBAB5
+#define FLASH_MAGIC_HW 0xC0FEC0FE   // THIS MAGIC SHOULD NOT CHANGE
 #define FLASH_EMPTY 0XFFFFFFFF
 #define FLASH_INVALIDATED 0xB0B0BABE
 
@@ -46,8 +47,6 @@ typedef struct {
     uint32_t magic;
     EAnimationType animation;
     ETextEffect textEffect;
-    EHardwareType hardwareType;
-    EPixelType pixelType;
     uint32_t perfectImperfections;
     char hierbenikUrl[MAX_URL_SIZE];
     char hierbenikPort[MAX_PORT_SIZE];
@@ -66,7 +65,18 @@ typedef struct {
     uint32_t magic_end;
 } TSettings;
 
+// The HW settings are static for a certain hardware build.
+// This prevents unreadable clocks when TSettings is updated (13x13 clock is unreadale when set to 11x11)
+// By splitting this settings, TSettings can freely be changed and assigned new defaults,
+typedef struct {
+    uint32_t magic;
+    EHardwareType hardwareType;
+    EPixelType pixelType;
+    uint8_t reserved[256];
+} THwSettings;
+
 TSettings g_settings __attribute__((aligned(4)));
+THwSettings g_hw_settings __attribute__((aligned(4)));
 
 #define COLOR_FROM_SETTING g_settings.color
 #define RGB_FROM_SETTING  ApplyBrightness(COLOR_FROM_SETTING.r), \

--- a/wordclock/wordclock_main.c
+++ b/wordclock/wordclock_main.c
@@ -149,7 +149,7 @@ void ShowTime(int delayMS) {
 		if (DoReDisplay) {
 			AlsFill(0,0,0);
 			AlsSetBackgroundColor(BGRGB_FROM_SETTING);
-			if (g_settings.hardwareType == HARDWARE_13_13 || g_settings.hardwareType == HARDWARE_13_13_V2) {
+			if (g_hw_settings.hardwareType == HARDWARE_13_13 || g_hw_settings.hardwareType == HARDWARE_13_13_V2) {
 				CWDisplayAccurateTime(h, m, s, RGB_FROM_SETTING);
 			} else {
 				CWDisplayTime(h, m, RGB_FROM_SETTING);


### PR DESCRIPTION
Doordat de settings magic met enige regelmaat veranderd worden de settings terug gezet naar default. nu is dat gedrag wel fijn want daarmee zijn de nieuwe settings gelijk goed ingesteld.

Echter is het ook zo dat een 13x13 clock terug valt naar een 11x11 waardoor die niet meer leesbaar is. ik vond dit wel een pragmatische oplossing

Closes #70